### PR TITLE
Add React Native support

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 isomorphic-fetch [![Build Status](https://travis-ci.org/matthew-andrews/isomorphic-fetch.svg?branch=master)](https://travis-ci.org/matthew-andrews/isomorphic-fetch)
 ================
 
-Fetch for node and Browserify.  Built on top of [GitHub's WHATWG Fetch polyfill](https://github.com/github/fetch).
+Fetch for node and Browserify. Also works in Webpack and React-Native Built on top of [GitHub's WHATWG Fetch polyfill](https://github.com/github/fetch).
 
 ## Warnings
 
@@ -18,20 +18,14 @@ For [ease-of-maintenance and backward-compatibility reasons][why polyfill], this
 ### NPM
 
 ```sh
-npm install --save isomorphic-fetch es6-promise
-```
-
-### Bower
-
-```sh
-bower install --save isomorphic-fetch es6-promise
+npm install --save portable-fetch es6-promise
 ```
 
 ## Usage
 
 ```js
 require('es6-promise').polyfill();
-require('isomorphic-fetch');
+require('portable-fetch');
 
 fetch('//offline-news-api.herokuapp.com/stories')
 	.then(function(response) {

--- a/fetch-npm-react-native.js
+++ b/fetch-npm-react-native.js
@@ -1,0 +1,1 @@
+module.exports = fetch;

--- a/package.json
+++ b/package.json
@@ -1,8 +1,9 @@
 {
-  "name": "isomorphic-fetch",
-  "version": "0.0.0",
-  "description": "Isomorphic WHATWG Fetch API, for Node & Browserify",
+  "name": "portable-fetch",
+  "version": "2.3.0",
+  "description": "Isomorphic WHATWG Fetch API, for Node, Browserify, Webpack & React-Native",
   "browser": "fetch-npm-browserify.js",
+  "react-native": "fetch-npm-react-native.js",
   "main": "fetch-npm-node.js",
   "scripts": {
     "files": "find . -name '*.js' ! -path './node_modules/*' ! -path './bower_components/*'",
@@ -10,14 +11,14 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/matthew-andrews/isomorphic-fetch.git"
+    "url": "https://github.com/knotis/isomorphic-fetch.git"
   },
   "author": "Matt Andrews <matt@mattandre.ws>",
   "license": "MIT",
   "bugs": {
-    "url": "https://github.com/matthew-andrews/isomorphic-fetch/issues"
+    "url": "https://github.com/knotis/isomorphic-fetch/issues"
   },
-  "homepage": "https://github.com/matthew-andrews/isomorphic-fetch/issues",
+  "homepage": "https://github.com/knotis/isomorphic-fetch/issues",
   "dependencies": {
     "node-fetch": "^1.0.1",
     "whatwg-fetch": ">=0.10.0"


### PR DESCRIPTION
* Add react native support by using the built in fetch method when react-native is the environment. Uses the "react-native" entrypoint setting in package.json.
* Changed project name to portable-fetch.
* Incremented minor version to 2.3.0.