### PR TITLE
Add Polyfill for process.nextTick for React-Native Environment.

### DIFF
--- a/fetch-npm-react-native.js
+++ b/fetch-npm-react-native.js
@@ -1,1 +1,7 @@
 module.exports = fetch;
+
+if (typeof process === 'undefined') process = {};
+process.nextTick = setImmediate;
+
+
+


### PR DESCRIPTION
* I added a simple polyfill that sets process.nextTick. I basically got it from: https://github.com/spencercarli/meteor-todos-react-native/blob/master/ReactNativeTodos/app/config/db/lib/process.polyfill.js. This fixes a call in one of the dependent libraries when building for react-native.